### PR TITLE
[Breaking] Update Moralis API URL to v2

### DIFF
--- a/lib/services/moralis/queries.dart
+++ b/lib/services/moralis/queries.dart
@@ -12,9 +12,11 @@ Future<List<NFT>> fetchUserNFTs(String owner, String network) async {
   List<NFT> allNfts = [];
   try {
     final queryResponse = await get(
-      Uri.parse("$baseUrl/$owner/nft?chain=$network&format=decimal"),
+      Uri.https(baseUrl!, "/api/v2/$owner/nft",
+          {"chain": network, "format": "decimal"}),
       headers: {
-        'x-api-key': _apiKey ?? "-",
+        "accept": "application/json",
+        'X-API-Key': _apiKey ?? "-",
       },
     );
 


### PR DESCRIPTION
- Updated `queries.dart` file to use version 2 (v2) of Moralis API URL for fetching NFTs

URL with placeholder address: `https://deep-index.moralis.io/api/v2/{address}/nft`. 

- `chain` and `format` are appended into following GET request as query parameters. 
- `x-api-key` and `accept` are appended into following GET request in request header.